### PR TITLE
fix: update chromium version to remove gn version check

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -11,7 +11,7 @@ gclient_gn_args = [
 
 vars = {
   'chromium_version':
-    '62358b57e3f5edc74843cbed117a64eb78aafe2f',
+    '903f3e3c0059b21427b21139ae9ac55ed1223de2',
   'node_version':
     'v12.8.1',
   'nan_version':


### PR DESCRIPTION
#### Description of Change

Updated chromium version in dependencies. This fixes issue related to
gn exec format error (part of leo-lb/electron#1) which occurs during
gn version check on ppc64le.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] tests are [changed or added](https://github.com/electron/electron/blob/master/docs/development/testing.md)
- [x] PR title follows semantic [commit guidelines](https://github.com/electron/electron/blob/master/docs/development/pull-requests.md#commit-message-guidelines)

#### Release Notes

Notes: `no-notes`